### PR TITLE
enable ssl validation

### DIFF
--- a/YTClient/YTClient.py
+++ b/YTClient/YTClient.py
@@ -38,10 +38,10 @@ class YTClient(object):
     def __init__(self, url, proxy_info=None, token=None):
         if proxy_info:
             self.http_client = httplib2.Http(
-                disable_ssl_certificate_validation=True, proxy_info=proxy_info)
+                disable_ssl_certificate_validation=False, proxy_info=proxy_info)
         else:
             self.http_client = httplib2.Http(
-                disable_ssl_certificate_validation=True)
+                disable_ssl_certificate_validation=False)
 
         self.baseUrl = url.rstrip('/')
         self.apiUrl = self.baseUrl + '/api'


### PR DESCRIPTION
Enable ssl validation in http client - targeting this branch has fixed the montagu task queue build - see this branch 
https://github.com/vimc/montagu-task-queue/pull/31
where there were previous failures on YT Client usage: ValueError: Cannot set verify_mode to CERT_NONE when check_hostname is enabled.